### PR TITLE
iconv related functions are deprecated in PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 before_script:
   - composer update --dev

--- a/src/String.php
+++ b/src/String.php
@@ -23,9 +23,16 @@ if (extension_loaded('mbstring'))
 if (function_exists('iconv'))
 {
 	// These are settings that can be set inside code
-	iconv_set_encoding("internal_encoding", "UTF-8");
-	iconv_set_encoding("input_encoding", "UTF-8");
-	iconv_set_encoding("output_encoding", "UTF-8");
+	if (version_compare(PHP_VERSION, '5.6', '>='))
+	{
+		@ini_set('default_charset', 'UTF-8');
+	}
+	else
+	{
+		iconv_set_encoding("internal_encoding", "UTF-8");
+		iconv_set_encoding("input_encoding", "UTF-8");
+		iconv_set_encoding("output_encoding", "UTF-8");
+	}
 }
 
 /**


### PR DESCRIPTION
In PHP 5.6, the `iconv_set_encoding()` function and the settings it controls are deprecated in favor of a `default_charset` setting, see https://wiki.php.net/rfc/default_encoding for more info.  The deprecation notices caused test errors on PHP 5.6.
