### PR TITLE
Setting mbstring.internal_encoding in PHP 5.6 is deprecated

### DIFF
--- a/src/String.php
+++ b/src/String.php
@@ -14,9 +14,16 @@ namespace Joomla\String;
 if (extension_loaded('mbstring'))
 {
 	// Make sure to suppress the output in case ini_set is disabled
-	@ini_set('mbstring.internal_encoding', 'UTF-8');
-	@ini_set('mbstring.http_input', 'UTF-8');
-	@ini_set('mbstring.http_output', 'UTF-8');
+	if (version_compare(PHP_VERSION, '5.6', '<'))
+	{
+		@ini_set('mbstring.internal_encoding', 'UTF-8');
+		@ini_set('mbstring.http_input', 'UTF-8');
+		@ini_set('mbstring.http_output', 'UTF-8');
+	}
+	else
+	{
+		@ini_set('default_charset', 'UTF-8');
+	}
 }
 
 // Same for iconv

--- a/src/String.php
+++ b/src/String.php
@@ -9,32 +9,22 @@
 namespace Joomla\String;
 
 // PHP mbstring and iconv local configuration
-
-// Check if mbstring extension is loaded and attempt to load it if not present except for windows
-if (extension_loaded('mbstring'))
+if (version_compare(PHP_VERSION, '5.6', '>='))
 {
-	// Make sure to suppress the output in case ini_set is disabled
-	if (version_compare(PHP_VERSION, '5.6', '<'))
+	@ini_set('default_charset', 'UTF-8');
+}
+else
+{
+	// Check if mbstring extension is loaded and attempt to load it if not present except for windows
+	if (extension_loaded('mbstring'))
 	{
 		@ini_set('mbstring.internal_encoding', 'UTF-8');
 		@ini_set('mbstring.http_input', 'UTF-8');
 		@ini_set('mbstring.http_output', 'UTF-8');
 	}
-	else
-	{
-		@ini_set('default_charset', 'UTF-8');
-	}
-}
-
-// Same for iconv
-if (function_exists('iconv'))
-{
-	// These are settings that can be set inside code
-	if (version_compare(PHP_VERSION, '5.6', '>='))
-	{
-		@ini_set('default_charset', 'UTF-8');
-	}
-	else
+	
+	// Same for iconv
+	if (function_exists('iconv'))
 	{
 		iconv_set_encoding("internal_encoding", "UTF-8");
 		iconv_set_encoding("input_encoding", "UTF-8");


### PR DESCRIPTION
In PHP 5.6 the internal encoding is deprecated which can result in an error message. The setting default charset should be used instead. Documentation can be found here http://php.net/manual/en/mbstring.configuration.php#ini.mbstring.internal-encoding.

This issue was previously reported on the Joomla CMS https://github.com/joomla/joomla-cms/pull/6405.