### PR TITLE
Don't cache plurals when inflection not found

### DIFF
--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -423,6 +423,7 @@ class Inflector
 		}
 
 		$this->setCache($word, $inflected);
+
 		return false;
 	}
 

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -419,12 +419,10 @@ class Inflector
 
 		if ($inflected !== false)
 		{
-			$this->setCache($word, $inflected);
-
 			return $inflected;
 		}
 
-		// Dead code
+		$this->setCache($word, $inflected);
 		return false;
 	}
 


### PR DESCRIPTION
Checking a plural word with isSingular() loads the plural into the cache as if it were singular.

To reproduce:

```
$inflector = \Joomla\String\Inflector::getInstance();
$inflector->isSingular('tags');
```

This returns `true` and leaves the cache with:

```
 [cache:Joomla\String\Inflector:private] => Array
        (
            [deer] => deer
            [moose] => moose
            [sheep] => sheep
            [bison] => bison
            [salmon] => salmon
            [pike] => pike
            [trout] => trout
            [fish] => fish
            [swine] => swine
            [alias] => aliases
            [bus] => buses
            [foot] => feet
            [goose] => geese
            [hive] => hives
            [louse] => lice
            [man] => men
            [mouse] => mice
            [ox] => oxen
            [quiz] => quizes
            [status] => statuses
            [tooth] => teeth
            [woman] => women
            [tags] => tags
        )
```

I'm not totally convinced this is the correct patch, but it does fix the problem and I've tested with the full permutations:

```
$inflector->isSingular('tags');
$inflector->isPlural('tags');
$inflector->isSingular('tag');
$inflector->isPlural('tag');
```

Note that I'm skipping the part where I reinstantiate from scratch for each test.
