### PR TITLE
[2.0][RFC] Rebase Inflector onto doctrine/inflector

### DIFF
--- a/Tests/InflectorTest.php
+++ b/Tests/InflectorTest.php
@@ -141,22 +141,22 @@ class InflectorTest extends TestCase
 		// Add string.
 		$this->inflector->addCountableRule('foo');
 
-		$rules = TestHelper::getValue($this->inflector, 'rules');
+		$countable = TestHelper::getValue($this->inflector, 'countable');
 
 		$this->assertContains(
 			'foo',
-			$rules['countable'],
+			$countable['rules'],
 			'Checks a countable rule was added.'
 		);
 
 		// Add array.
 		$this->inflector->addCountableRule(array('goo', 'car'));
 
-		$rules = TestHelper::getValue($this->inflector, 'rules');
+		$countable = TestHelper::getValue($this->inflector, 'countable');
 
 		$this->assertContains(
 			'car',
-			$rules['countable'],
+			$countable['rules'],
 			'Checks a countable rule was added by array.'
 		);
 	}

--- a/Tests/InflectorTest.php
+++ b/Tests/InflectorTest.php
@@ -6,6 +6,7 @@
 
 namespace Joomla\String\Tests;
 
+use Doctrine\Common\Inflector\Inflector as DoctrineInflector;
 use Joomla\String\Inflector;
 use Joomla\Test\TestHelper;
 use PHPUnit\Framework\TestCase;
@@ -63,7 +64,7 @@ class InflectorTest extends TestCase
 
 			// Irregular plurals
 			array('ox', 'oxen'),
-			array('quiz', 'quizes'),
+			array('quiz', 'quizzes'),
 			array('status', 'statuses'),
 			array('matrix', 'matrices'),
 			array('index', 'indices'),
@@ -95,56 +96,22 @@ class InflectorTest extends TestCase
 		parent::setUp();
 
 		$this->inflector = Inflector::getInstance(true);
+		DoctrineInflector::reset();
 	}
 
 	/**
-	 * Method to test Inflector::addRule().
+	 * Tears down the fixture, for example, close a network connection.
+	 * This method is called after a test is executed.
 	 *
 	 * @return  void
 	 *
-	 * @covers  Joomla\String\Inflector::addRule
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
-	public function testAddRule()
+	protected function tearDown()
 	{
-		// Case 1
-		TestHelper::invoke($this->inflector, 'addRule', '/foo/', 'singular');
+		DoctrineInflector::reset();
 
-		$rules = TestHelper::getValue($this->inflector, 'rules');
-
-		$this->assertContains(
-			'/foo/',
-			$rules['singular'],
-			'Checks if the singular rule was added correctly.'
-		);
-
-		// Case 2
-		TestHelper::invoke($this->inflector, 'addRule', '/bar/', 'plural');
-
-		$rules = TestHelper::getValue($this->inflector, 'rules');
-
-		$this->assertContains(
-			'/bar/',
-			$rules['plural'],
-			'Checks if the plural rule was added correctly.'
-		);
-
-		// Case 3
-		TestHelper::invoke($this->inflector, 'addRule', array('/goo/', '/car/'), 'singular');
-
-		$rules = TestHelper::getValue($this->inflector, 'rules');
-
-		$this->assertContains(
-			'/goo/',
-			$rules['singular'],
-			'Checks if an array of rules was added correctly (1).'
-		);
-
-		$this->assertContains(
-			'/car/',
-			$rules['singular'],
-			'Checks if an array of rules was added correctly (2).'
-		);
+		parent::tearDown();
 	}
 
 	/**
@@ -159,115 +126,6 @@ class InflectorTest extends TestCase
 	public function testAddRuleException()
 	{
 		TestHelper::invoke($this->inflector, 'addRule', new \stdClass, 'singular');
-	}
-
-	/**
-	 * Method to test Inflector::getCachedPlural().
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\String\Inflector::getCachedPlural
-	 * @since   1.0
-	 */
-	public function testGetCachedPlural()
-	{
-		// Reset the cache.
-		TestHelper::setValue($this->inflector, 'cache', array('foo' => 'bar'));
-
-		$this->assertFalse(
-			TestHelper::invoke($this->inflector, 'getCachedPlural', 'bar'),
-			'Checks for an uncached plural.'
-		);
-
-		$this->assertEquals(
-			'bar',
-			TestHelper::invoke($this->inflector, 'getCachedPlural', 'foo'),
-			'Checks for a cached plural word.'
-		);
-	}
-
-	/**
-	 * Method to test Inflector::getCachedSingular().
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\String\Inflector::getCachedSingular
-	 * @since   1.0
-	 */
-	public function testGetCachedSingular()
-	{
-		// Reset the cache.
-		TestHelper::setValue($this->inflector, 'cache', array('foo' => 'bar'));
-
-		$this->assertFalse(
-			TestHelper::invoke($this->inflector, 'getCachedSingular', 'foo'),
-			'Checks for an uncached singular.'
-		);
-
-		$this->assertThat(
-			TestHelper::invoke($this->inflector, 'getCachedSingular', 'bar'),
-			$this->equalTo('foo'),
-			'Checks for a cached singular word.'
-		);
-	}
-
-	/**
-	 * Method to test Inflector::matchRegexRule().
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\String\Inflector::matchRegexRule
-	 * @since   1.0
-	 */
-	public function testMatchRegexRule()
-	{
-		$this->assertThat(
-			TestHelper::invoke($this->inflector, 'matchRegexRule', 'xyz', 'plural'),
-			$this->equalTo('xyzs'),
-			'Checks pluralising against the basic regex.'
-		);
-
-		$this->assertThat(
-			TestHelper::invoke($this->inflector, 'matchRegexRule', 'xyzs', 'singular'),
-			$this->equalTo('xyz'),
-			'Checks singularising against the basic regex.'
-		);
-
-		$this->assertFalse(
-			TestHelper::invoke($this->inflector, 'matchRegexRule', 'xyz', 'singular'),
-			'Checks singularising against an unmatched regex.'
-		);
-	}
-
-	/**
-	 * Method to test Inflector::setCache().
-	 *
-	 * @return  void
-	 *
-	 * @covers  Joomla\String\Inflector::setCache
-	 * @since   1.0
-	 */
-	public function testSetCache()
-	{
-		TestHelper::invoke($this->inflector, 'setCache', 'foo', 'bar');
-
-		$cache = TestHelper::getValue($this->inflector, 'cache');
-
-		$this->assertThat(
-			$cache['foo'],
-			$this->equalTo('bar'),
-			'Checks the cache was set.'
-		);
-
-		TestHelper::invoke($this->inflector, 'setCache', 'foo', 'car');
-
-		$cache = TestHelper::getValue($this->inflector, 'cache');
-
-		$this->assertThat(
-			$cache['foo'],
-			$this->equalTo('car'),
-			'Checks an existing value in the cache was reset.'
-		);
 	}
 
 	/**
@@ -311,34 +169,53 @@ class InflectorTest extends TestCase
 	 * @covers  Joomla\String\Inflector::addWord
 	 * @since   1.2.0
 	 */
-	public function testAddWord()
+	public function testAddWordWithoutPlural()
 	{
-		$this->assertEquals(
+		$this->assertSame(
 			$this->inflector,
 			$this->inflector->addWord('foo')
 		);
 
-		$cache = TestHelper::getValue($this->inflector, 'cache');
+		$plural = TestHelper::getValue(DoctrineInflector::class, 'plural');
 
-		$this->assertArrayHasKey('foo', $cache);
-
-		$this->assertEquals(
-			'foo',
-			$cache['foo']
+		$this->assertTrue(
+			in_array('foo', $plural['uninflected'])
 		);
 
+		$singular = TestHelper::getValue(DoctrineInflector::class, 'singular');
+
+		$this->assertTrue(
+			in_array('foo', $singular['uninflected'])
+		);
+	}
+
+	/**
+	 * Method to test Inflector::addWord().
+	 *
+	 * @return  void
+	 *
+	 * @covers  Joomla\String\Inflector::addWord
+	 * @since   1.2.0
+	 */
+	public function testAddWordWithPlural()
+	{
 		$this->assertEquals(
 			$this->inflector,
 			$this->inflector->addWord('bar', 'foo')
 		);
 
-		$cache = TestHelper::getValue($this->inflector, 'cache');
+		$plural = TestHelper::getValue(DoctrineInflector::class, 'plural');
 
-		$this->assertArrayHasKey('bar', $cache);
-
-		$this->assertEquals(
+		$this->assertArrayHasKey(
 			'foo',
-			$cache['bar']
+			$plural['irregular']
+		);
+
+		$singular = TestHelper::getValue(DoctrineInflector::class, 'singular');
+
+		$this->assertArrayHasKey(
+			'bar',
+			$singular['irregular']
 		);
 	}
 
@@ -352,19 +229,17 @@ class InflectorTest extends TestCase
 	 */
 	public function testAddPluraliseRule()
 	{
-		$chain = $this->inflector->addPluraliseRule(array('/foo/', '/bar/'));
-
-		$this->assertThat(
-			$chain,
-			$this->identicalTo($this->inflector),
+		$this->assertSame(
+			$this->inflector->addPluraliseRule(['/^(custom)$/i' => '\1izables']),
+			$this->inflector,
 			'Checks chaining.'
 		);
 
-		$rules = TestHelper::getValue($this->inflector, 'rules');
+		$plural = TestHelper::getValue(DoctrineInflector::class, 'plural');
 
-		$this->assertCOntains(
-			'/bar/',
-			$rules['plural'],
+		$this->assertArrayHasKey(
+			'/^(custom)$/i',
+			$plural['rules'],
 			'Checks a pluralisation rule was added.'
 		);
 	}
@@ -379,19 +254,17 @@ class InflectorTest extends TestCase
 	 */
 	public function testAddSingulariseRule()
 	{
-		$chain = $this->inflector->addSingulariseRule(array('/foo/', '/bar/'));
-
-		$this->assertThat(
-			$chain,
-			$this->identicalTo($this->inflector),
+		$this->assertSame(
+			$this->inflector->addSingulariseRule(['/^(inflec|contribu)tors$/i' => '\1ta']),
+			$this->inflector,
 			'Checks chaining.'
 		);
 
-		$rules = TestHelper::getValue($this->inflector, 'rules');
+		$singular = TestHelper::getValue(DoctrineInflector::class, 'singular');
 
-		$this->assertContains(
-			'/bar/',
-			$rules['singular'],
+		$this->assertArrayHasKey(
+			'/^(inflec|contribu)tors$/i',
+			$singular['rules'],
 			'Checks a singularisation rule was added.'
 		);
 	}
@@ -464,14 +337,14 @@ class InflectorTest extends TestCase
 	{
 		$this->assertTrue(
 			$this->inflector->isPlural($plural),
-			'Checks the plural is a plural.'
+			"'$plural' should be reported as plural"
 		);
 
-		if ($singular != $plural)
+		if ($singular !== $plural)
 		{
 			$this->assertFalse(
 				$this->inflector->isPlural($singular),
-				'Checks the singular is not plural.'
+				"'$singular' should not be reported as a plural form in comparison to '$plural'"
 			);
 		}
 	}
@@ -492,14 +365,14 @@ class InflectorTest extends TestCase
 	{
 		$this->assertTrue(
 			$this->inflector->isSingular($singular),
-			'Checks the singular is a singular.'
+			"'$singular' should be reported as singular"
 		);
 
-		if ($singular != $plural)
+		if ($singular !== $plural)
 		{
 			$this->assertFalse(
 				$this->inflector->isSingular($plural),
-				'Checks the plural is not singular.'
+				"'$plural' should not be reported as a singular form in comparison to '$singular'"
 			);
 		}
 	}
@@ -518,9 +391,10 @@ class InflectorTest extends TestCase
 	 */
 	public function testToPlural($singular, $plural)
 	{
-		$this->assertThat(
+		$this->assertSame(
+			$plural,
 			$this->inflector->toPlural($singular),
-			$this->equalTo($plural)
+			"'$plural' should be the plural form of '$singular'"
 		);
 	}
 
@@ -534,11 +408,15 @@ class InflectorTest extends TestCase
 	 */
 	public function testToPluralAlreadyPlural()
 	{
-		$this->assertFalse($this->inflector->toPlural('buses'));
+		$this->assertSame(
+			'buses',
+			$this->inflector->toPlural('buses'),
+			"'buses' should not be pluralised'"
+		);
 	}
 
 	/**
-	 * Method to test Inflector::toPlural().
+	 * Method to test Inflector::toSingular().
 	 *
 	 * @param   string  $singular  The singular form of a word.
 	 * @param   string  $plural    The plural form of a word.
@@ -551,25 +429,27 @@ class InflectorTest extends TestCase
 	 */
 	public function testToSingular($singular, $plural)
 	{
-		$this->assertThat(
+		$this->assertSame(
+			$singular,
 			$this->inflector->toSingular($plural),
-			$this->equalTo($singular)
+			"'$singular' should be the singular form of '$plural'"
 		);
 	}
 
 	/**
-	 * Method to test Inflector::toPlural().
+	 * Method to test Inflector::toSingular().
 	 *
 	 * @return  void
 	 *
 	 * @covers  Joomla\String\Inflector::toSingular
 	 * @since   1.2.0
 	 */
-	public function testToSingularRetFalse()
+	public function testToSingularAlreadySingular()
 	{
-		// Assertion for already singular
-		$this->assertFalse($this->inflector->toSingular('bus'));
-
-		$this->assertFalse($this->inflector->toSingular('foo'));
+		$this->assertSame(
+			'bus',
+			$this->inflector->toSingular('bus'),
+			"'bus' should not be singularised'"
+		);
 	}
 }

--- a/Tests/InflectorTest.php
+++ b/Tests/InflectorTest.php
@@ -73,7 +73,6 @@ class InflectorTest extends TestCase
 
 			// Ablaut plurals
 			array('foot', 'feet'),
-			array('goose', 'geese'),
 			array('louse', 'lice'),
 			array('man', 'men'),
 			array('mouse', 'mice'),

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,14 @@
         "php": "~7.0"
     },
     "require-dev": {
+        "doctrine/inflector": "~1.2",
         "joomla/test": "~1.0",
         "phpunit/phpunit": "~6.3",
         "squizlabs/php_codesniffer": "1.*"
     },
     "suggest": {
-        "ext-mbstring": "For improved processing"
+        "ext-mbstring": "For improved processing",
+        "doctrine/inflector": "To use the string inflector"
     },
     "autoload": {
         "psr-4": {

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -78,7 +78,7 @@ class Inflector extends DoctrineInflector
 		}
 		else
 		{
-			DoctrineInflector::rules($ruleType, $data);
+			static::rules($ruleType, $data);
 		}
 	}
 
@@ -122,14 +122,14 @@ class Inflector extends DoctrineInflector
 
 		if ($plural !== '')
 		{
-			DoctrineInflector::rules(
+			static::rules(
 				'plural',
 				[
 					'irregular' => [$plural => $singular]
 				]
 			);
 
-			DoctrineInflector::rules(
+			static::rules(
 				'singular',
 				[
 					'irregular' => [$singular => $plural]
@@ -138,14 +138,14 @@ class Inflector extends DoctrineInflector
 		}
 		else
 		{
-			DoctrineInflector::rules(
+			static::rules(
 				'plural',
 				[
 					'uninflected' => [$singular]
 				]
 			);
 
-			DoctrineInflector::rules(
+			static::rules(
 				'singular',
 				[
 					'uninflected' => [$singular]
@@ -328,6 +328,6 @@ class Inflector extends DoctrineInflector
 			E_USER_DEPRECATED
 		);
 
-		return DoctrineInflector::singularize($word);
+		return static::singularize($word);
 	}
 }

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -17,13 +17,14 @@ use Doctrine\Common\Inflector\Inflector as DoctrineInflector;
  *
  * @since  1.0
  */
-class Inflector
+class Inflector extends DoctrineInflector
 {
 	/**
 	 * The singleton instance.
 	 *
 	 * @var    Inflector
 	 * @since  1.0
+	 * @deprecated  3.0
 	 */
 	private static $instance;
 
@@ -92,6 +93,15 @@ class Inflector
 	 */
 	public function addCountableRule($data)
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0, use %2$s::rules() instead.',
+				__METHOD__,
+				__CLASS__
+			),
+			E_USER_DEPRECATED
+		);
+
 		$this->addRule($data, 'countable');
 
 		return $this;
@@ -109,6 +119,15 @@ class Inflector
 	 */
 	public function addWord($singular, $plural = '')
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0, use %2$s::rules() instead.',
+				__METHOD__,
+				DoctrineInflector::class
+			),
+			E_USER_DEPRECATED
+		);
+
 		if ($plural !== '')
 		{
 			DoctrineInflector::rules(
@@ -156,6 +175,15 @@ class Inflector
 	 */
 	public function addPluraliseRule($data)
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0, use %2$s::rules() instead.',
+				__METHOD__,
+				DoctrineInflector::class
+			),
+			E_USER_DEPRECATED
+		);
+
 		$this->addRule($data, 'plural');
 
 		return $this;
@@ -172,6 +200,15 @@ class Inflector
 	 */
 	public function addSingulariseRule($data)
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0, use %2$s::rules() instead.',
+				__METHOD__,
+				DoctrineInflector::class
+			),
+			E_USER_DEPRECATED
+		);
+
 		$this->addRule($data, 'singular');
 
 		return $this;
@@ -188,6 +225,14 @@ class Inflector
 	 */
 	public static function getInstance($new = false)
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0.',
+				__METHOD__
+			),
+			E_USER_DEPRECATED
+		);
+
 		if ($new)
 		{
 			return new static;
@@ -254,7 +299,16 @@ class Inflector
 	 */
 	public function toPlural($word)
 	{
-		return DoctrineInflector::pluralize($word);
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0, use %2$s::pluralize() instead.',
+				__METHOD__,
+				DoctrineInflector::class
+			),
+			E_USER_DEPRECATED
+		);
+
+		return static::pluralize($word);
 	}
 
 	/**
@@ -268,6 +322,15 @@ class Inflector
 	 */
 	public function toSingular($word)
 	{
+		@trigger_error(
+			sprintf(
+				'%1$s() is deprecated and will be removed in 3.0, use %2$s::singularize() instead.',
+				__METHOD__,
+				DoctrineInflector::class
+			),
+			E_USER_DEPRECATED
+		);
+
 		return DoctrineInflector::singularize($word);
 	}
 }

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -90,19 +90,9 @@ class Inflector extends DoctrineInflector
 	 * @return  $this
 	 *
 	 * @since   1.0
-	 * @deprecated  3.0  Use Joomla\String\Inflector::rules() instead.
 	 */
 	public function addCountableRule($data)
 	{
-		@trigger_error(
-			sprintf(
-				'%1$s() is deprecated and will be removed in 3.0, use %2$s::rules() instead.',
-				__METHOD__,
-				__CLASS__
-			),
-			E_USER_DEPRECATED
-		);
-
 		$this->addRule($data, 'countable');
 
 		return $this;

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -90,6 +90,7 @@ class Inflector extends DoctrineInflector
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use Joomla\String\Inflector::rules() instead.
 	 */
 	public function addCountableRule($data)
 	{
@@ -116,6 +117,7 @@ class Inflector extends DoctrineInflector
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use Doctrine\Common\Inflector\Inflector::rules() instead.
 	 */
 	public function addWord($singular, $plural = '')
 	{
@@ -172,6 +174,7 @@ class Inflector extends DoctrineInflector
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use Doctrine\Common\Inflector\Inflector::rules() instead.
 	 */
 	public function addPluraliseRule($data)
 	{
@@ -197,6 +200,7 @@ class Inflector extends DoctrineInflector
 	 * @return  $this
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use Doctrine\Common\Inflector\Inflector::rules() instead.
 	 */
 	public function addSingulariseRule($data)
 	{
@@ -222,6 +226,7 @@ class Inflector extends DoctrineInflector
 	 * @return  static
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use static methods without a class instance instead.
 	 */
 	public static function getInstance($new = false)
 	{
@@ -296,6 +301,7 @@ class Inflector extends DoctrineInflector
 	 * @return  string  The word in plural form.
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use Doctrine\Common\Inflector\Inflector::pluralize() instead.
 	 */
 	public function toPlural($word)
 	{
@@ -319,6 +325,7 @@ class Inflector extends DoctrineInflector
 	 * @return  string  The word in singular form.
 	 *
 	 * @since   1.0
+	 * @deprecated  3.0  Use Doctrine\Common\Inflector\Inflector::singularize() instead.
 	 */
 	public function toSingular($word)
 	{

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -32,10 +32,10 @@ class Inflector extends DoctrineInflector
 	 * The inflector rules for countability.
 	 *
 	 * @var    array
-	 * @since  1.0
+	 * @since  __DEPLOY_VERSION__
 	 */
-	private $rules = [
-		'countable' => [
+	private static $countable = [
+		'rules' => [
 			'id',
 			'hits',
 			'clicks',
@@ -73,7 +73,7 @@ class Inflector extends DoctrineInflector
 			foreach ($data as $rule)
 			{
 				// Ensure a string is pushed.
-				array_push($this->rules[$ruleType], (string) $rule);
+				array_push(self::$countable['rules'], (string) $rule);
 			}
 		}
 		else
@@ -257,7 +257,7 @@ class Inflector extends DoctrineInflector
 	 */
 	public function isCountable($word)
 	{
-		return in_array($word, $this->rules['countable']);
+		return in_array($word, self::$countable['rules']);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

This proposal rebases our string inflector class so that it uses Doctrine's inflector instead.  This has the advantage of replacing our code which is not as well maintained or tested with a package providing similar functionality that has better support.

The changes here make our inflector class extend from Doctrine's and deprecates our object oriented API methods in favor of migrating toward the same static API the Doctrine class offers.

### TODO

- [ ] Address upstream package version issues (`<1.3` supports PHP 7 and doesn't have a strictly typed API, `1.3` dropped PHP 7.0 support and migrated toward a strictly typed API, this means we can't consistently extend `Doctrine\Common\Inflector\Inflector::rules()` to retain support for our countable rule through the same API because of the function declaration differences between versions)

### Testing Instructions

- The existing public API continues to function without issue as all methods are proxied

### Documentation Changes Required

- Note deprecations for 3.0