### PR TITLE
Correct warning "A non-numeric value encountered" in utf8.php

### DIFF
--- a/src/phputf8/utf8.php
+++ b/src/phputf8/utf8.php
@@ -42,7 +42,7 @@ if ( extension_loaded('mbstring')) {
      * and https://github.com/php/php-src/commit/97df99a6d7d96a886ac143337fecad775907589a
      * for additional references
      */
-    if ( PHP_VERSION_ID < 80000 && ini_get('mbstring.func_overload') & MB_OVERLOAD_STRING ) {
+    if ( PHP_VERSION_ID < 80000 && ((int) ini_get('mbstring.func_overload')) & MB_OVERLOAD_STRING ) {
         trigger_error('String functions are overloaded by mbstring',E_USER_ERROR);
     }
     mb_internal_encoding('UTF-8');


### PR DESCRIPTION
Pull Request for new issue.

### Summary of Changes

See [https://github.com/joomla/joomla-cms/pull/25234](https://github.com/joomla/joomla-cms/pull/25234).

ini_get returns string "0" or "1" or whatever, which has to be type-casted to int before bitwise and.

### Testing Instructions

Code review and read [https://github.com/joomla/joomla-cms/pull/25234](https://github.com/joomla/joomla-cms/pull/25234).

### Documentation Changes Required

None.