### PR TITLE
Remove PHP 7.4 deprecated curly brace access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.phar
 composer.lock
 phpunit.xml
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ matrix:
       env: COMPOSER_FLAGS=""
     - php: 7.2
     - php: 7.3
+    - php: 7.4
     - php: nightly
   allow_failures:
+    - php: 7.4
     - php: nightly
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ matrix:
       env: COMPOSER_FLAGS=""
     - php: 7.2
     - php: 7.3
-    - php: 7.4
+    - php: 7.4snapshot
     - php: nightly
   allow_failures:
-    - php: 7.4
+    - php: 7.4snapshot
     - php: nightly
 
 before_script:

--- a/src/phputf8/ord.php
+++ b/src/phputf8/ord.php
@@ -20,33 +20,33 @@ function utf8_ord($chr) {
         return $ord0;
     }
 
-    if ( !isset($chr{1}) ) {
+    if ( !isset($chr[1]) ) {
         trigger_error('Short sequence - at least 2 bytes expected, only 1 seen');
         return FALSE;
     }
 
-    $ord1 = ord($chr{1});
+    $ord1 = ord($chr[1]);
     if ( $ord0 >= 192 && $ord0 <= 223 ) {
         return ( $ord0 - 192 ) * 64
             + ( $ord1 - 128 );
     }
 
-    if ( !isset($chr{2}) ) {
+    if ( !isset($chr[2]) ) {
         trigger_error('Short sequence - at least 3 bytes expected, only 2 seen');
         return FALSE;
     }
-    $ord2 = ord($chr{2});
+    $ord2 = ord($chr[2]);
     if ( $ord0 >= 224 && $ord0 <= 239 ) {
         return ($ord0-224)*4096
             + ($ord1-128)*64
                 + ($ord2-128);
     }
 
-    if ( !isset($chr{3}) ) {
+    if ( !isset($chr[3]) ) {
         trigger_error('Short sequence - at least 4 bytes expected, only 3 seen');
         return FALSE;
     }
-    $ord3 = ord($chr{3});
+    $ord3 = ord($chr[3]);
     if ($ord0>=240 && $ord0<=247) {
         return ($ord0-240)*262144
             + ($ord1-128)*4096
@@ -55,11 +55,11 @@ function utf8_ord($chr) {
 
     }
 
-    if ( !isset($chr{4}) ) {
+    if ( !isset($chr[4]) ) {
         trigger_error('Short sequence - at least 5 bytes expected, only 4 seen');
         return FALSE;
     }
-    $ord4 = ord($chr{4});
+    $ord4 = ord($chr[4]);
     if ($ord0>=248 && $ord0<=251) {
         return ($ord0-248)*16777216
             + ($ord1-128)*262144
@@ -68,7 +68,7 @@ function utf8_ord($chr) {
                         + ($ord4-128);
     }
 
-    if ( !isset($chr{5}) ) {
+    if ( !isset($chr[5]) ) {
         trigger_error('Short sequence - at least 6 bytes expected, only 5 seen');
         return FALSE;
     }
@@ -78,7 +78,7 @@ function utf8_ord($chr) {
                 + ($ord2-128)*262144
                     + ($ord3-128)*4096
                         + ($ord4-128)*64
-                            + (ord($chr{5})-128);
+                            + (ord($chr[5])-128);
     }
 
     if ( $ord0 >= 254 && $ord0 <= 255 ) {

--- a/src/phputf8/ord.php
+++ b/src/phputf8/ord.php
@@ -7,6 +7,12 @@
 /**
 * UTF-8 aware alternative to ord
 * Returns the unicode ordinal for a character
+*
+* Joomla modification - As of PHP 7.4, curly brace access has been deprecated. As a result this function has been
+* modified to use square brace syntax
+* See https://github.com/php/php-src/commit/d574df63dc375f5fc9202ce5afde23f866b6450a
+* for additional references
+*
 * @param string UTF-8 encoded character
 * @return int unicode ordinal for the character
 * @see http://www.php.net/ord

--- a/src/phputf8/utils/validation.php
+++ b/src/phputf8/utils/validation.php
@@ -37,6 +37,12 @@ function utf8_is_valid($str) {
 
     for($i = 0; $i < $len; $i++) {
 
+        /*
+         * Joomla modification - As of PHP 7.4, curly brace access has been deprecated. As a result the line below has
+         * been modified to use square brace syntax
+         * See https://github.com/php/php-src/commit/d574df63dc375f5fc9202ce5afde23f866b6450a
+         * for additional references
+         */
         $in = ord($str[$i]);
 
         if ( $mState == 0) {

--- a/src/phputf8/utils/validation.php
+++ b/src/phputf8/utils/validation.php
@@ -37,7 +37,7 @@ function utf8_is_valid($str) {
 
     for($i = 0; $i < $len; $i++) {
 
-        $in = ord($str{$i});
+        $in = ord($str[$i]);
 
         if ( $mState == 0) {
 


### PR DESCRIPTION
Fixes PHP deprecation warnings in PHP 7.4 and adds testing (as an allowed failure for now)