### PR TITLE
Normalise::toVariable() cleanup

### DIFF
--- a/src/Normalise.php
+++ b/src/Normalise.php
@@ -125,19 +125,14 @@ abstract class Normalise
 	 */
 	public static function toVariable($input)
 	{
-		// Remove dashes and underscores, then convert to camel case.
-		$input = self::toSpaceSeparated($input);
+		// Convert to camel case.
 		$input = self::toCamelCase($input);
 
 		// Remove leading digits.
 		$input = preg_replace('#^[0-9]+#', '', $input);
 
 		// Lowercase the first character.
-		$first = substr($input, 0, 1);
-		$first = strtolower($first);
-
-		// Replace the first character with the lowercase character.
-		$input = substr_replace($input, $first, 0, 1);
+		$input = lcfirst($input);
 
 		return $input;
 	}


### PR DESCRIPTION
### Summary of Changes

Remove redundant `toSpaceSeparated()` call.
Use `lcfirst()` to lowercase first character.

### Testing Instructions

Tests should pass.

### Documentation Changes Required
No.