### PR TITLE
Remove PHP 7.4 deprecated curly brace access

### DIFF
--- a/src/phputf8/utils/unicode.php
+++ b/src/phputf8/utils/unicode.php
@@ -12,6 +12,7 @@
 * @see http://lxr.mozilla.org/seamonkey/source/intl/uconv/src/nsUnicodeToUTF8.cpp
 * @see http://hsivonen.iki.fi/php-utf8/
 * @package utf8
+* @note This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
 */
 
 //--------------------------------------------------------------------
@@ -43,7 +44,7 @@ function utf8_to_unicode($str) {
 
     for($i = 0; $i < $len; $i++) {
 
-        $in = ord($str{$i});
+        $in = ord($str[$i]);
 
         if ( $mState == 0) {
 


### PR DESCRIPTION
### Summary of Changes

Fixes notice:

>Deprecated: Array and string offset access syntax with curly braces is deprecated in vendor\joomla\string\src\phputf8\utils\unicode.php on line 46

### Testing Instructions

Code review.

### Documentation Changes Required

No.