### PR TITLE
Fixes deprecation warning with php 8.1+

### DIFF
--- a/src/phputf8/mbstring/core.php
+++ b/src/phputf8/mbstring/core.php
@@ -21,7 +21,7 @@ if ( !defined('UTF8_CORE') ) {
 * @package utf8
 */
 function utf8_strlen($str){
-    return mb_strlen($str ?? "");
+    return mb_strlen($str ?? '');
 }
 
 

--- a/src/phputf8/mbstring/core.php
+++ b/src/phputf8/mbstring/core.php
@@ -21,7 +21,7 @@ if ( !defined('UTF8_CORE') ) {
 * @package utf8
 */
 function utf8_strlen($str){
-    return mb_strlen($str);
+    return mb_strlen($str ?? "");
 }
 
 


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Fixes ```Deprecated: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated in E:\Bearsampp\www\j4\libraries\vendor\joomla\string\src\phputf8\mbstring\core.php on line 24``` error in patch_tester

### Testing Instructions
install https://github.com/joomla-extensions/patchtester/releases/tag/4.2.1
enter your credentials 
click on "fetch data"
you will get a popup with several warnings.
apply this patch and the mb_strlen warning will go away

### Documentation Changes Required
none