### PR TITLE
Update StringHelper.php

### DIFF
--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -267,8 +267,8 @@ abstract class StringHelper
 	 *
 	 * Case-insensitive version of str_replace()
 	 *
-	 * @param   string                $search   String to search
-	 * @param   string                $replace  Existing string to replace
+	 * @param   string|array          $search   String to search
+	 * @param   string|array          $replace  Existing string to replace
 	 * @param   string                $str      New string to replace with
 	 * @param   integer|null|boolean  $count    Optional count value to be passed by referene
 	 *


### PR DESCRIPTION
Fixing missing type hint for `str_replace` as it accepts and is used also with arrays

Pull Request for Issue #

### Summary of Changes

### Testing Instructions

### Documentation Changes Required
