### PR TITLE
Fix typehint for str_ireplace

### DIFF
--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -257,8 +257,8 @@ abstract class StringHelper
      *
      * Case-insensitive version of str_replace()
      *
-     * @param   string                $search   String to search
-     * @param   string                $replace  Existing string to replace
+     * @param   string|array          $search   String to search
+     * @param   string|array          $replace  Existing string to replace
      * @param   string                $str      New string to replace with
      * @param   integer|null|boolean  $count    Optional count value to be passed by referene
      *


### PR DESCRIPTION
This is a remake of #44. Thanks @artur-stepien!

Fixing missing type hint for str_replace as it accepts and is used also with arrays