### PR TITLE
Refactor alias and title increment logic in StringHelper

### DIFF
--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -57,14 +57,7 @@ abstract class StringHelper
         $styleSpec = static::$incrementStyles[$style] ?? static::$incrementStyles['default'];
 
         // Regular expression search and replace patterns for both cases
-        if ($style === 'default') {
-            if (preg_match('#\((\d+)\)$#', $string, $matches)) {
-                $n = empty($n) ? ($matches[1] + 1) : $n;
-                $string = preg_replace('#\((\d+)\)$#', "($n)", $string);
-            } else {
-                $string .= ' (2)';
-            }
-        } else {
+        if ($style === 'dash') {
             $rxSearch = '#-(\d+)$#';  // Match the trailing number after a hyphen (e.g., "dog-2")
             $rxReplace = '-%d';        // Replace it with "-number"
 
@@ -74,6 +67,14 @@ abstract class StringHelper
             } else {
                 $n = empty($n) ? 2 : $n;
                 $string .= sprintf($rxReplace, $n);
+            }
+        } else {
+            if (preg_match('#\((\d+)\)$#', $string, $matches)) {
+                $n = empty($n) ? ($matches[1] + 1) : $n;
+                $string = preg_replace('#\((\d+)\)$#', "($n)", $string);
+            } else {
+                $n = empty($n) ? 2 : $n;
+                $string .= " ($n)";
             }
         }
 

--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -56,29 +56,25 @@ abstract class StringHelper
     {
         $styleSpec = static::$incrementStyles[$style] ?? static::$incrementStyles['default'];
 
-        // Regular expression search and replace patterns.
-        if (\is_array($styleSpec[0])) {
-            $rxSearch  = $styleSpec[0][0];
-            $rxReplace = $styleSpec[0][1];
+        // Regular expression search and replace patterns for both cases
+        if ($style === 'default') {
+            if (preg_match('#\((\d+)\)$#', $string, $matches)) {
+                $n = empty($n) ? ($matches[1] + 1) : $n;
+                $string = preg_replace('#\((\d+)\)$#', "($n)", $string);
+            } else {
+                $string .= ' (2)';
+            }
         } else {
-            $rxSearch = $rxReplace = $styleSpec[0];
-        }
+            $rxSearch = '#-(\d+)$#';  // Match the trailing number after a hyphen (e.g., "dog-2")
+            $rxReplace = '-%d';        // Replace it with "-number"
 
-        // New and old (existing) sprintf formats.
-        if (\is_array($styleSpec[1])) {
-            $newFormat = $styleSpec[1][0];
-            $oldFormat = $styleSpec[1][1];
-        } else {
-            $newFormat = $oldFormat = $styleSpec[1];
-        }
-
-        // Check if we are incrementing an existing pattern, or appending a new one.
-        if (preg_match($rxSearch, $string, $matches)) {
-            $n      = empty($n) ? ($matches[1] + 1) : $n;
-            $string = preg_replace($rxReplace, sprintf($oldFormat, $n), $string);
-        } else {
-            $n = empty($n) ? 2 : $n;
-            $string .= sprintf($newFormat, $n);
+            if (preg_match($rxSearch, $string, $matches)) {
+                $n = empty($n) ? ($matches[1] + 1) : $n;
+                $string = preg_replace($rxReplace, sprintf($rxReplace, $n), $string);
+            } else {
+                $n = empty($n) ? 2 : $n;
+                $string .= sprintf($rxReplace, $n);
+            }
         }
 
         return $string;


### PR DESCRIPTION
Pull Request for Issue #[45011](https://github.com/joomla/joomla-cms/issues/45011)

### Summary of Changes
Modified the increment function in the StringHelper file with the same logic @chmst suggested. First, the function checks the format of the string by determining the style. If the default style is used, it checks if the string contains a number inside parentheses. If a number is present, it increments the number inside the parentheses. If no number is found, it appends (2) to the title. If the dash style is used, it checks if the string ends with a number preceded by a hyphen. If a number is present, it increments it. If no number is found, it appends -2 to the alias. I would appreciate any help or suggestions to ensure this solution works as expected across various use cases.
 
### Testing Instructions
When merged with joomla-cms, 
Example Test: Create an article that has
Title: August 2024
Alias: august-2024

Save as copy
Title: August 2024 (2)
Expected Alias: august-2024-2

This method supports two formats for string incrementing:
 
 1. Title Format (Default Style): For titles, the increment will be handled inside parentheses.
    - Example: `"dog"` becomes `"dog (2)"`, and `"dog (2)"` becomes `"dog (3)"`.
    - If the title does not already have a number inside parentheses, it appends `(2)` by default.
 
 2. Alias Format (Dash Style): For aliases, the increment will be handled with a hyphen (`-`).
    - Example: `"dog-2"` becomes `"dog-3"`.
    - If the alias does not have a number after the hyphen, it appends `-2` by default.
    

https://github.com/user-attachments/assets/32658cc7-9079-4075-a587-9a78742edf1b


   

### Documentation Changes Required
