### PR TITLE
[3.x][PHP8.5] Passing a string which is not a single byte to ord() is deprecated

### DIFF
--- a/src/phputf8/ord.php
+++ b/src/phputf8/ord.php
@@ -21,7 +21,7 @@
 */
 function utf8_ord($chr)
 {
-    $ord0 = ord($chr);
+    $ord0 = ord($chr[0]);
 
     if ($ord0 >= 0 && $ord0 <= 127) {
         return $ord0;


### PR DESCRIPTION
### Summary of Changes

> The ord() function accepts the empty string (in which case it uses the null byte that terminates the C string and returns 0) and strings longer than one byte (in which case it returns the value of the first byte).
> Both of these cases indicate some sort of programming bug, as such we propose deprecating this behaviour.

> Deprecated: Providing a string which is not one byte long is deprecated, use $str[0] instead

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_passing_string_which_are_not_one_byte_long_to_ord

### Testing Instructions

Run unit tests `./vendor/bin/phpunit`
- enable max error reporting
- use php 8.5 (latest pre-version 8.5.0rc1)

### Documentation Changes Required

no