### PR TITLE
[3.x][PHP8.5] Using null as an array offset is now deprecated

### DIFF
--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -54,6 +54,7 @@ abstract class StringHelper
      */
     public static function increment($string, $style = 'default', $n = 0)
     {
+        $style ??= 'default';
         $styleSpec = static::$incrementStyles[$style] ?? static::$incrementStyles['default'];
 
         // Regular expression search and replace patterns.


### PR DESCRIPTION
### Summary of Changes

> Deprecated: Using null as an array offset is deprecated, use an empty string instead

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

### Testing Instructions

Run unit tests `./vendor/bin/phpunit`
- enable max error reporting
- use php 8.5 (latest pre-version 8.5.0rc1)

### Documentation Changes Required

no