### PR TITLE
[4.x] update dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         "joomla/test": "^4.0",
         "phpunit/phpunit": "^12.2.6 || ^13.0",
         "squizlabs/php_codesniffer": "^4.0",
-        "phpstan/phpstan": "2.1.17",
-        "phpstan/phpstan-deprecation-rules": "2.0.3"
+        "phpstan/phpstan": "^2.1.17",
+        "phpstan/phpstan-deprecation-rules": "^2.0.3"
     },
     "suggest": {
         "ext-mbstring": "For improved processing",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "doctrine/inflector": "^2.0.10",
         "joomla/test": "^4.0",
         "phpunit/phpunit": "^12.2.6 || ^13.0",
-        "squizlabs/php_codesniffer": "^3.7.2",
+        "squizlabs/php_codesniffer": "^4.0",
         "phpstan/phpstan": "2.1.17",
         "phpstan/phpstan-deprecation-rules": "2.0.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "doctrine/inflector": "^2.0.10",
         "joomla/test": "^4.0",
-        "phpunit/phpunit": "^12.2.6",
+        "phpunit/phpunit": "^12.2.6 || ^13.0",
         "squizlabs/php_codesniffer": "^3.7.2",
         "phpstan/phpstan": "2.1.17",
         "phpstan/phpstan-deprecation-rules": "2.0.3"


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

- allow phpunit 13 (php 8.4 and above)
- use php_codesniffer version 4
- relax phpstan version

### Testing Instructions

ci/cd

### Documentation Changes Required

no