### PR TITLE
[4.x] fix StringHelper::strspn (deprecation message)

### DIFF
--- a/src/StringHelper.php
+++ b/src/StringHelper.php
@@ -539,11 +539,11 @@ abstract class StringHelper
     {
         $mask = preg_replace('!([\\\\\\-\\]\\[/^])!', '\\\${1}', $mask);
 
-        if ($start && $length) {
+        if ($start !== null && $length !== null) {
             $str = mb_substr($str, $start, $length);
-        } elseif ($start) {
+        } elseif ($start !== null) {
             $str = mb_substr($str, $start);
-        } elseif ($length) {
+        } elseif ($length !== null) {
             trigger_error('\Joomla\String\StringHelper::strspn(): Passing null to parameter #3 ($start) of type int is deprecated', E_USER_DEPRECATED);
             $str = mb_substr($str, 0, $length);
         }


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes

`if (0) {}` is validated as `false` 
so this call `StringHelper::strspn('321 Main Street', '0123456789', 0, 2);` results in wrong deprecation message:
`\Joomla\String\StringHelper::strspn(): Passing null to parameter #3 ($start) of type int is deprecated`

### Testing Instructions

execute `StringHelper::strspn('321 Main Street', '0123456789', 0, 2);`
result is `2` but without wrong deprecation message

### Documentation Changes Required

no
